### PR TITLE
Use ES6 import instead of require to pull in 'sum' to sum-test

### DIFF
--- a/src/__tests__/sum-test.js
+++ b/src/__tests__/sum-test.js
@@ -1,6 +1,6 @@
 jest.dontMock('../sum'); // or jest.autoMockOff();
 
-var sum = require('../sum')['default'];
+import sum from '../sum';
 
 describe('sum', function () {
     it('adds 1 + 2 to equal 3', function () {


### PR DESCRIPTION
Test was failing due to use of require instead of ES6 import.

(command output skipped for all except 'npm test')

➜ git clone https://github.com/hipertracker/react-es7.git
Cloning into 'react-es7'...
➜  cd react-es7
➜  npm install
➜  bower install
➜  npm test

> react-es7@0.0.10 test /Users/brendon/Experiments/react-es7
> jest

Using Jest CLI v0.2.2
 FAIL  src/**tests**/sum-test.js (0.477s)
● sum › it adds 1 + 2 to equal 3
- TypeError: undefined is not a function
      at Spec.<anonymous> (/Users/brendon/Experiments/react-es7/src/**tests**/sum-test.js:9:16)
      at jasmine.Block.execute (/Users/brendon/Experiments/react-es7/node_modules/jest-cli/vendor/jasmine/jasmine-1.3.0.js:1065:17)
      at jasmine.Queue.next_ (/Users/brendon/Experiments/react-es7/node_modules/jest-cli/vendor/jasmine/jasmine-1.3.0.js:2098:31)
      at null._onTimeout (/Users/brendon/Experiments/react-es7/node_modules/jest-cli/vendor/jasmine/jasmine-1.3.0.js:2088:18)
      at Timer.listOnTimeout [as ontimeout](timers.js:112:15)
  1 test failed, 0 tests passed (1 total)
  Run time: 0.659s
  npm ERR! Test failed.  See above for more details.
